### PR TITLE
Mensagem de erro formulário de criação de conta

### DIFF
--- a/app/models/custom_attribute_definition.rb
+++ b/app/models/custom_attribute_definition.rb
@@ -13,6 +13,7 @@
 #
 # Indexes
 #
+#  attribute_key_model_index                         (attribute_key,attribute_model) UNIQUE
 #  index_custom_attribute_definitions_on_account_id  (account_id)
 #
 class CustomAttributeDefinition < ApplicationRecord

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <h1 class="typography-title-b-lh150 text-dark-palette-p4 text-center mb-3">Registrar</h1>
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }) do |f| %>
 <%= render "devise/shared/error_messages", resource: resource %>
   <div class="grid gap-5">
     <%= f.fields_for :account, resource.build_account do |account_fields| %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2024_04_19_183543) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["account_id"], name: "index_custom_attribute_definitions_on_account_id"
+    t.index ["attribute_key", "attribute_model"], name: "attribute_key_model_index", unique: true
   end
 
   create_table "deals", force: :cascade do |t|


### PR DESCRIPTION
Aparentemente o Turbo espera uma resposta de redirecionamento apos a submissão de um formulário, (https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission) estamos enviado 422. Desativei o turbo no formulario de criação de novas contas com `data: {turbo: false}` e as mensagens de erro apareceram normalmente.