### PR TITLE
Add index migration to contacts chatwoot_id in additional_attributes and add scope

### DIFF
--- a/app/controllers/accounts/contacts/chatwoot_embed_controller.rb
+++ b/app/controllers/accounts/contacts/chatwoot_embed_controller.rb
@@ -57,9 +57,7 @@ class Accounts::Contacts::ChatwootEmbedController < InternalController
   end
 
   def contact_search
-    result = current_user.account.contacts.where(
-      "additional_attributes->>'chatwoot_id' = ?", chatwoot_contact['id'].to_s
-    ).first
+    result = current_user.account.contacts.by_chatwoot_id(chatwoot_contact['id']).first
     return result if result.present?
 
     Accounts::Contacts::GetByParams.call(current_user.account,

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -15,10 +15,10 @@
 #
 # Indexes
 #
-#  index_contacts_on_additional_attributes_gin  (additional_attributes) USING gin
-#  index_contacts_on_app                        (app_type,app_id)
-#  index_contacts_on_lower_email                (lower(NULLIF((email)::text, ''::text))) UNIQUE
-#  index_contacts_on_phone                      (NULLIF((phone)::text, ''::text)) UNIQUE
+#  index_contacts_on_app          (app_type,app_id)
+#  index_contacts_on_chatwoot_id  (((additional_attributes ->> 'chatwoot_id'::text)))
+#  index_contacts_on_lower_email  (lower(NULLIF((email)::text, ''::text))) UNIQUE
+#  index_contacts_on_phone        (NULLIF((phone)::text, ''::text)) UNIQUE
 #
 class Contact < ApplicationRecord
   include Labelable
@@ -42,6 +42,9 @@ class Contact < ApplicationRecord
 
   has_many :deals, dependent: :destroy
   belongs_to :app, polymorphic: true, optional: true
+  scope :by_chatwoot_id, lambda { |chatwoot_id|
+    chatwoot_id.present? ? where("additional_attributes->>'chatwoot_id' = ?", chatwoot_id.to_s) : none
+  }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[additional_attributes app_id app_type created_at custom_attributes email full_name id

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -16,7 +16,7 @@
 # Indexes
 #
 #  index_contacts_on_app          (app_type,app_id)
-#  index_contacts_on_chatwoot_id  (((additional_attributes ->> 'chatwoot_id'::text)))
+#  index_contacts_on_chatwoot_id  (((additional_attributes ->> 'chatwoot_id'::text))) WHERE ((additional_attributes -> 'chatwoot_id'::text) IS NOT NULL)
 #  index_contacts_on_lower_email  (lower(NULLIF((email)::text, ''::text))) UNIQUE
 #  index_contacts_on_phone        (NULLIF((phone)::text, ''::text)) UNIQUE
 #

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -15,9 +15,10 @@
 #
 # Indexes
 #
-#  index_contacts_on_app          (app_type,app_id)
-#  index_contacts_on_lower_email  (lower(NULLIF((email)::text, ''::text))) UNIQUE
-#  index_contacts_on_phone        (NULLIF((phone)::text, ''::text)) UNIQUE
+#  index_contacts_on_additional_attributes_gin  (additional_attributes) USING gin
+#  index_contacts_on_app                        (app_type,app_id)
+#  index_contacts_on_lower_email                (lower(NULLIF((email)::text, ''::text))) UNIQUE
+#  index_contacts_on_phone                      (NULLIF((phone)::text, ''::text)) UNIQUE
 #
 class Contact < ApplicationRecord
   include Labelable

--- a/app/use_cases/accounts/apps/chatwoots/webhooks/import_contact.rb
+++ b/app/use_cases/accounts/apps/chatwoots/webhooks/import_contact.rb
@@ -5,8 +5,8 @@ class Accounts::Apps::Chatwoots::Webhooks::ImportContact
   end
 
   def self.get_or_import_contact(chatwoot, contact_id)
-    contact = Contact.where("CAST(additional_attributes->>'chatwoot_id' AS INTEGER) = ?",
-                                              contact_id).first
+    contact = Contact.by_chatwoot_id(contact_id).first
+
     contact_att = get_contact(chatwoot, contact_id)
     return 'Contact not found' if contact_att == false
 

--- a/db/migrate/20250926060748_add_gin_index_to_contacts_additional_attributes.rb
+++ b/db/migrate/20250926060748_add_gin_index_to_contacts_additional_attributes.rb
@@ -1,5 +1,0 @@
-class AddGinIndexToContactsAdditionalAttributes < ActiveRecord::Migration[7.1]
-  def change
-    add_index :contacts, :additional_attributes, using: :gin, name: 'index_contacts_on_additional_attributes_gin'
-  end
-end

--- a/db/migrate/20250926060748_add_gin_index_to_contacts_additional_attributes.rb
+++ b/db/migrate/20250926060748_add_gin_index_to_contacts_additional_attributes.rb
@@ -1,0 +1,5 @@
+class AddGinIndexToContactsAdditionalAttributes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :contacts, :additional_attributes, using: :gin, name: 'index_contacts_on_additional_attributes_gin'
+  end
+end

--- a/db/migrate/20250926060748_add_index_to_contacts_additional_attributes_chatwoot_id.rb
+++ b/db/migrate/20250926060748_add_index_to_contacts_additional_attributes_chatwoot_id.rb
@@ -1,5 +1,8 @@
 class AddIndexToContactsAdditionalAttributesChatwootId < ActiveRecord::Migration[7.1]
   def change
-    add_index :contacts, "(additional_attributes->>'chatwoot_id')", name: 'index_contacts_on_chatwoot_id'
+    add_index :contacts,
+              "(additional_attributes->>'chatwoot_id')",
+              name: 'index_contacts_on_chatwoot_id',
+              where: "additional_attributes->'chatwoot_id' IS NOT NULL"
   end
 end

--- a/db/migrate/20250926060748_add_index_to_contacts_additional_attributes_chatwoot_id.rb
+++ b/db/migrate/20250926060748_add_index_to_contacts_additional_attributes_chatwoot_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToContactsAdditionalAttributesChatwootId < ActiveRecord::Migration[7.1]
+  def change
+    add_index :contacts, "(additional_attributes->>'chatwoot_id')", name: 'index_contacts_on_chatwoot_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_11_234351) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_26_060748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,6 +134,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_11_234351) do
     t.datetime "updated_at", null: false
     t.index "NULLIF((phone)::text, ''::text)", name: "index_contacts_on_phone", unique: true
     t.index "lower(NULLIF((email)::text, ''::text))", name: "index_contacts_on_lower_email", unique: true
+    t.index ["additional_attributes"], name: "index_contacts_on_additional_attributes_gin", using: :gin
     t.index ["app_type", "app_id"], name: "index_contacts_on_app"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -132,7 +132,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_26_060748) do
     t.bigint "app_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "((additional_attributes ->> 'chatwoot_id'::text))", name: "index_contacts_on_chatwoot_id"
+    t.index "((additional_attributes ->> 'chatwoot_id'::text))", name: "index_contacts_on_chatwoot_id", where: "((additional_attributes -> 'chatwoot_id'::text) IS NOT NULL)"
     t.index "NULLIF((phone)::text, ''::text)", name: "index_contacts_on_phone", unique: true
     t.index "lower(NULLIF((email)::text, ''::text))", name: "index_contacts_on_lower_email", unique: true
     t.index ["app_type", "app_id"], name: "index_contacts_on_app"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -132,9 +132,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_26_060748) do
     t.bigint "app_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index "((additional_attributes ->> 'chatwoot_id'::text))", name: "index_contacts_on_chatwoot_id"
     t.index "NULLIF((phone)::text, ''::text)", name: "index_contacts_on_phone", unique: true
     t.index "lower(NULLIF((email)::text, ''::text))", name: "index_contacts_on_lower_email", unique: true
-    t.index ["additional_attributes"], name: "index_contacts_on_additional_attributes_gin", using: :gin
     t.index ["app_type", "app_id"], name: "index_contacts_on_app"
   end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -15,9 +15,10 @@
 #
 # Indexes
 #
-#  index_contacts_on_app          (app_type,app_id)
-#  index_contacts_on_lower_email  (lower(NULLIF((email)::text, ''::text))) UNIQUE
-#  index_contacts_on_phone        (NULLIF((phone)::text, ''::text)) UNIQUE
+#  index_contacts_on_additional_attributes_gin  (additional_attributes) USING gin
+#  index_contacts_on_app                        (app_type,app_id)
+#  index_contacts_on_lower_email                (lower(NULLIF((email)::text, ''::text))) UNIQUE
+#  index_contacts_on_phone                      (NULLIF((phone)::text, ''::text)) UNIQUE
 #
 require 'rails_helper'
 RSpec.describe Contact do

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -15,10 +15,10 @@
 #
 # Indexes
 #
-#  index_contacts_on_additional_attributes_gin  (additional_attributes) USING gin
-#  index_contacts_on_app                        (app_type,app_id)
-#  index_contacts_on_lower_email                (lower(NULLIF((email)::text, ''::text))) UNIQUE
-#  index_contacts_on_phone                      (NULLIF((phone)::text, ''::text)) UNIQUE
+#  index_contacts_on_app          (app_type,app_id)
+#  index_contacts_on_chatwoot_id  (((additional_attributes ->> 'chatwoot_id'::text)))
+#  index_contacts_on_lower_email  (lower(NULLIF((email)::text, ''::text))) UNIQUE
+#  index_contacts_on_phone        (NULLIF((phone)::text, ''::text)) UNIQUE
 #
 require 'rails_helper'
 RSpec.describe Contact do

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -16,7 +16,7 @@
 # Indexes
 #
 #  index_contacts_on_app          (app_type,app_id)
-#  index_contacts_on_chatwoot_id  (((additional_attributes ->> 'chatwoot_id'::text)))
+#  index_contacts_on_chatwoot_id  (((additional_attributes ->> 'chatwoot_id'::text))) WHERE ((additional_attributes -> 'chatwoot_id'::text) IS NOT NULL)
 #  index_contacts_on_lower_email  (lower(NULLIF((email)::text, ''::text))) UNIQUE
 #  index_contacts_on_phone        (NULLIF((phone)::text, ''::text)) UNIQUE
 #


### PR DESCRIPTION
## Antes da migração do index GIN
```ruby
irb(main):034* Contact.where(
irb(main):035*   "additional_attributes @> ?", { chatwoot_id: 123 }.to_json
irb(main):036> )
  Contact Load (422.3ms)  SELECT "contacts".* FROM "contacts" WHERE (additional_attributes @> '{"chatwoot_id":123}') /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
``` 
## Depois da migração do index GIN
```ruby
irb(main):006* Contact.where(
irb(main):007*   "additional_attributes @> ?", { chatwoot_id: 123 }.to_json
irb(main):008> )
  Contact Load (3.6ms)  SELECT "contacts".* FROM "contacts" WHERE (additional_attributes @> '{"chatwoot_id":123}') /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
```
### Tipos de consultas do chatwoot_id 
```ruby
# Por algum motivo em desenvolvimento as queries q usam '->>' e o CAST estão mais performaticas q o '@>',
# porém acho q a gnt deve migrar todos para '@>', pois ele usará o index GIN, q na teoria é mais performatico.
Contact.where("CAST(additional_attributes->>'chatwoot_id' AS INTEGER) = ?",
204074).first

Contact.where(
  "additional_attributes @> ?", { chatwoot_id: 204074 }.to_json
)

Contact.where(
  "additional_attributes->>'chatwoot_id' = ?", 204074.to_s
    ).first
``` 

### Observações
1. O index GIN só é acionado para queries q usam o `@>`
2. Esse teste foi feito em desenvolvimento
3. A Query q está pesando em produção está usando o CAST, que foi implementado nesse pr #463, e eu testei em desenvolvimento e rodou em 2 ms ou algo parecido, e n teve diferença antes e dps da implementação do index GIN.
4. As mudanças de consulta para '@>', iremos fazer em outro pr, pois temos q testar na pratica para ve se ele ira puxar o contato pela consulta corretamente. Tem a situação q foi corrigida no pr #463, e pode voltar a acontecer elimando o CAST e migrando para o `@>`, por isso q temos q testar bem antes de fazer essas mudanças

### Consultas que n fizeram diferença do antes e depois do GIN.
## Antes da migração do index GIN
```ruby
irb(main):044* Contact.where(
irb(main):045*   "additional_attributes->>'chatwoot_id' = ?", 123.to_s
irb(main):046>     ).first
  Contact Load (1.2ms)  SELECT "contacts".* FROM "contacts" WHERE (additional_attributes->>'chatwoot_id' = '123') ORDER BY "contacts"."id" ASC LIMIT $1  [["LIMIT", 1]]

irb(main):042* Contact.where("CAST(additional_attributes->>'chatwoot_id' AS INTEGER) = ?",
irb(main):043> 123456789).first
  Contact Load (0.8ms)  SELECT "contacts".* FROM "contacts" WHERE (CAST(additional_attributes->>'chatwoot_id' AS INTEGER) = 123456789) ORDER BY "contacts"."id" ASC LIMIT $1  [["LIMIT", 1]]
``` 
## Depois da migração do index GIN
```ruby
irb(main):001* Contact.where(
irb(main):002*   "additional_attributes->>'chatwoot_id' = ?", 123.to_s
irb(main):003>     ).first
  Contact Load (2.5ms)  SELECT "contacts".* FROM "contacts" WHERE (additional_attributes->>'chatwoot_id' = '123') ORDER BY "contacts"."id" ASC LIMIT $1  [["LIMIT", 1]]

irb(main):010* Contact.where("CAST(additional_attributes->>'chatwoot_id' AS INTEGER) = ?",
irb(main):011> 123456789).first
  Contact Load (2.0ms)  SELECT "contacts".* FROM "contacts" WHERE (CAST(additional_attributes->>'chatwoot_id' AS INTEGER) = 123456789) ORDER BY "contacts"."id" ASC LIMIT $1  [["LIMIT", 1]]
```
 