### PR TITLE
FIx reports deals timeseries builder test

### DIFF
--- a/spec/builders/reports/deals/timeseries/base_report_builder_spec.rb
+++ b/spec/builders/reports/deals/timeseries/base_report_builder_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Reports::Deals::Timeseries::BaseReportBuilder do
   describe '#timeseries' do
     let(:grouped_count_mock) do
       {
-        Time.zone.parse('2025-06-07').to_date => 0,
-        Time.zone.parse('2025-06-08').to_date => 0,
-        Time.zone.parse('2025-06-09').to_date => 0,
-        Time.zone.parse('2025-06-10').to_date => 1,
-        Time.zone.parse('2025-06-11').to_date => 1,
-        Time.zone.parse('2025-06-12').to_date => 0,
-        Time.zone.parse('2025-06-13').to_date => 0
+        Time.zone.parse('2025-12-07').to_date => 0,
+        Time.zone.parse('2025-12-08').to_date => 0,
+        Time.zone.parse('2025-12-09').to_date => 0,
+        Time.zone.parse('2025-12-10').to_date => 1,
+        Time.zone.parse('2025-12-11').to_date => 1,
+        Time.zone.parse('2025-12-12').to_date => 0,
+        Time.zone.parse('2025-12-13').to_date => 0
       }
     end
 
@@ -35,13 +35,13 @@ RSpec.describe Reports::Deals::Timeseries::BaseReportBuilder do
 
       let(:expected_result) do
         [
-          { value: 0, timestamp: 1_749_265_200 },
-          { value: 0, timestamp: 1_749_351_600 },
-          { value: 0, timestamp: 1_749_438_000 },
-          { value: 1, timestamp: 1_749_524_400 },
-          { value: 1, timestamp: 1_749_610_800 },
-          { value: 0, timestamp: 1_749_697_200 },
-          { value: 0, timestamp: 1_749_783_600 }
+          { value: 0, timestamp: 1_765_076_400 },
+          { value: 0, timestamp: 1_765_162_800 },
+          { value: 0, timestamp: 1_765_249_200 },
+          { value: 1, timestamp: 1_765_335_600 },
+          { value: 1, timestamp: 1_765_422_000 },
+          { value: 0, timestamp: 1_765_508_400 },
+          { value: 0, timestamp: 1_765_594_800 }
         ]
       end
 


### PR DESCRIPTION
Esse teste começou a falhar do nada pq o `timezone_offset` no params está setado para `-03:00`, e o metodo que pega o timezone (`app/helpers/timezone_helper.rb`) para gerar as datas dos reports, está retornando `Santiago`, até ai tudo bem, pois dependendo dos meses que esse processo é rodado, o timezone -03:00 será mesmo Santiago.
Mas o problema em si é q quando eu criei esse teste, eu mockei o `grouped_count` para retornar o relatorio no mês de `junho`, e o mês de `junho` o UTC de Santiago é `-4` por conta de horario de verão, e no periodo que eu fiz esse teste, provavelmente o metodo `timezone`, oriundo do `timezone_name_from_offset`, ele retornou outro timezone, e com isso o expect, por estar fixo, foi configurado para as datas do timezone daquele periodo que o teste foi criado.
Para solucionar esse problema, eu mockei o `grouped_count` para os relatorios retornar datas nos meses onde o timezone de Santiago fosse igual a do America/Sao_Paulo q é `-3`, com isso eu alterei as datas do expect para retornar o timestamp nessas datas, e o teste terá falha independente de quando ele for rodar.