### PR TITLE
Fix Chatwoot import crashing on contacts without a name

### DIFF
--- a/app/use_cases/accounts/apps/chatwoots/sync_import_contacts.rb
+++ b/app/use_cases/accounts/apps/chatwoots/sync_import_contacts.rb
@@ -62,8 +62,12 @@ class Accounts::Apps::Chatwoots::SyncImportContacts
   end
 
   def build_contact_att(body)
+    # Chatwoot allows contacts without a name (e.g. WhatsApp contacts identified
+    # only by phone number). `full_name` is NOT NULL in the database, so passing a
+    # nil name raises PG::NotNullViolation and aborts the whole import. Fall back to
+    # the phone number, then the email, so the contact is still imported.
     contact = @account.contacts.new(
-      full_name: body['name'],
+      full_name: body['name'].presence || body['phone_number'].presence || body['email'].presence || 'Unknown',
       email: (body['email']).to_s,
       phone: (body['phone_number']).to_s
     )

--- a/spec/integration/use_cases/accounts/apps/chatwoots/sync_import_conctacts_spec.rb
+++ b/spec/integration/use_cases/accounts/apps/chatwoots/sync_import_conctacts_spec.rb
@@ -74,6 +74,27 @@ RSpec.describe Accounts::Apps::Chatwoots::SyncImportContacts, type: :request do
           expect(no_chatwoot_id_contacts.first.id).to eq(contact.id)
         end
       end
+      context 'when a chatwoot contact has no name' do
+        let(:contact_without_name) do
+          { meta: { count: 1, current_page: '1' },
+            payload: [{ id: 999, name: nil, email: nil, phone_number: '+551432015784',
+                        identifier: nil, additional_attributes: {}, custom_attributes: {} }] }.to_json
+        end
+        let(:empty_page) { { meta: { count: 0, current_page: '2' }, payload: [] }.to_json }
+        before do
+          stub_request(:get, "#{chatwoot.chatwoot_endpoint_url}/api/v1/accounts/#{chatwoot.chatwoot_account_id}/contacts/")
+            .with(query: { page: 1 }, headers: chatwoot.request_headers)
+            .to_return(status: 200, body: contact_without_name, headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, "#{chatwoot.chatwoot_endpoint_url}/api/v1/accounts/#{chatwoot.chatwoot_account_id}/contacts/")
+            .with(query: { page: 2 }, headers: chatwoot.request_headers)
+            .to_return(status: 200, body: empty_page, headers: { 'Content-Type' => 'application/json' })
+        end
+        it 'imports the contact using the phone number as a fallback name instead of raising' do
+          expect { Accounts::Apps::Chatwoots::SyncImportContacts.new(chatwoot).call }
+            .to change { account.contacts.count }.by(1)
+          expect(account.contacts.last.full_name).to eq('+551432015784')
+        end
+      end
       context 'check contact tags and conversations tags' do
         it do
           Accounts::Apps::Chatwoots::SyncImportContacts.new(chatwoot).call


### PR DESCRIPTION
## Problem

Chatwoot allows contacts without a name (e.g. WhatsApp contacts identified only by phone number). Because `contacts.full_name` is `NOT NULL`, importing such a contact raises `PG::NotNullViolation`.

That exception is not rescued in `SyncImportContacts#update_or_create_contact` (the code only handles the `contact.save == false` validation path), so a single nameless contact aborts the **entire** import run and puts the `SyncChatwootWorker` Sidekiq job into an infinite retry loop, blocking the whole contact sync.

This was hit in a real self-hosted instance: 17 WhatsApp contacts without a name kept the Chatwoot sync permanently broken.

## Fix

In `build_contact_att`, fall back to the phone number, then the email, then `"Unknown"`, so the contact is still imported with a meaningful name. This mirrors what Chatwoot itself already does for WhatsApp contacts (their name is the phone number), keeping the imported data consistent.

```ruby
full_name: body['name'].presence || body['phone_number'].presence || body['email'].presence || 'Unknown',
```

Contacts that already have a name are unaffected.

## Test

Added a spec covering a Chatwoot contact with a `null` name: it must be imported using the phone number as a fallback instead of raising. Verified red→green — without the change the new example fails with `PG::NotNullViolation` on `if contact.save`; with the change the full `SyncImportContacts` spec passes (7 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)