### PR TITLE
Add WhatsApp template support to scheduled Chatwoot messages

### DIFF
--- a/app/controllers/accounts/pipelines_controller.rb
+++ b/app/controllers/accounts/pipelines_controller.rb
@@ -132,7 +132,9 @@ class Accounts::PipelinesController < InternalController
     elsif !params['event']['scheduled_at'].nil?
       time_start = params['event']['scheduled_at'].in_time_zone
     end
-    @result = @deals.each_with_index do |deal, index|
+    @created = 0
+    @skipped = []
+    @deals.each_with_index do |deal, index|
       if params['event']['kind'] == 'chatwoot_message' || params['event']['kind'] == 'evolution_api_message'
         if params['event']['send_now'] == 'true'
           time_start += rand(10..15).seconds
@@ -145,11 +147,20 @@ class Accounts::PipelinesController < InternalController
                                 event_params.merge({ contact: deal.contact, scheduled_at: time_start })).build
       @event.deal = deal
 
-      if !@event.valid? && index == 0
+      # A template variable mapped to a contact field this lead is missing (e.g.
+      # no name) would be rejected by WhatsApp — skip the lead and report it.
+      if @event.chatwoot_template_missing_data?
+        @skipped << deal
+        next
+      end
+
+      # Stop only on a genuine configuration error on the first deal (bad template
+      # selection, missing media header…), not on a per-lead data gap.
+      if !@event.valid? && index.zero?
         render :new_bulk_action, status: :unprocessable_entity
         return
       end
-      @event.save
+      @created += 1 if @event.save
     end
     respond_to do |format|
       format.turbo_stream

--- a/app/javascript/controllers/chatwoot_template_form_controller.js
+++ b/app/javascript/controllers/chatwoot_template_form_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
     "preview",
     "contentSection",
   ];
-  static values = { inboxes: Array, saved: Object };
+  static values = { inboxes: Array, saved: Object, mergeFields: Array };
 
   connect() {
     // On edit, the inbox select is not pre-selected by Rails (jsonb hash), so
@@ -95,15 +95,69 @@ export default class extends Controller {
     const saved = this.savedValue.body_params || {};
     this.bodyVarIndexes(body.text).forEach((index, position) => {
       this.bodyParamsTarget.appendChild(
-        this.field(
-          `event[additional_attributes][template_body_params][${index}]`,
-          `Variável {{${index}}}`,
-          examples[position] || "",
-          saved[index] || "",
-          "body-param",
-        ),
+        this.bodyParamField(index, examples[position] || "", saved[index] || ""),
       );
     });
+  }
+
+  // A body variable input with a "source" selector: a fixed text, or a contact
+  // field that is resolved per lead at send time (a {{contact.<field>}} token).
+  // This is what makes a bulk send personalised (e.g. {{1}} = each lead's name).
+  bodyParamField(index, example, saved) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "space-y-1 mt-2";
+    const labelEl = document.createElement("label");
+    labelEl.className = "typography-text-s-lh150 text-dark-gray-palette-p1";
+    labelEl.textContent = `Variável {{${index}}}`;
+
+    const row = document.createElement("div");
+    row.className = "flex gap-2";
+
+    const select = document.createElement("select");
+    select.className = "form-input";
+    select.innerHTML =
+      `<option value="">${this.fixedTextLabel()}</option>` +
+      this.mergeFields()
+        .map((f) => `<option value="${f.key}">${f.label}</option>`)
+        .join("");
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.name = `event[additional_attributes][template_body_params][${index}]`;
+    input.placeholder = example || "";
+    input.className = "form-input w-full";
+    input.setAttribute("data-action", "input->chatwoot-template-form#updatePreview");
+
+    const applyContactField = (field) => {
+      input.value = `{{contact.${field}}}`;
+      input.readOnly = true;
+      input.classList.add("bg-light-palette-p4");
+    };
+    const applyFixedText = (value) => {
+      input.value = value || "";
+      input.readOnly = false;
+      input.classList.remove("bg-light-palette-p4");
+    };
+
+    const token = this.parseMergeToken(saved);
+    if (token) {
+      select.value = token;
+      applyContactField(token);
+    } else {
+      applyFixedText(saved);
+    }
+
+    select.addEventListener("change", () => {
+      if (select.value) applyContactField(select.value);
+      else applyFixedText("");
+      this.updatePreview();
+    });
+
+    row.appendChild(select);
+    row.appendChild(input);
+    wrapper.appendChild(labelEl);
+    wrapper.appendChild(row);
+    return wrapper;
   }
 
   renderHeaderMedia(components) {
@@ -140,9 +194,40 @@ export default class extends Controller {
     let text = (body && body.text) || "";
     this.bodyParamsTarget.querySelectorAll("input").forEach((input) => {
       const index = input.name.match(/\[template_body_params\]\[(\d+)\]/)[1];
-      text = text.replace(`{{${index}}}`, input.value || `{{${index}}}`);
+      const token = this.parseMergeToken(input.value);
+      const shown = token ? `«${this.mergeFieldLabel(token)}»` : input.value || `{{${index}}}`;
+      text = text.replace(`{{${index}}}`, shown);
     });
     this.previewTarget.textContent = text;
+  }
+
+  // --- merge tags ----------------------------------------------------------
+
+  // Contact fields offered as merge tags. Can be overridden from the view via
+  // data-…-merge-fields-value (e.g. to add custom attributes); falls back to the
+  // standard fields, which the Event model resolves server-side.
+  mergeFields() {
+    return this.hasMergeFieldsValue && this.mergeFieldsValue.length
+      ? this.mergeFieldsValue
+      : [
+          { key: "full_name", label: "Nome do contato" },
+          { key: "phone", label: "Telefone" },
+          { key: "email", label: "Email" },
+        ];
+  }
+
+  fixedTextLabel() {
+    return "Texto fixo";
+  }
+
+  parseMergeToken(value) {
+    const m = (value || "").match(/^\{\{\s*contact\.([a-z_]+(?:\.[A-Za-z0-9_ -]+)?)\s*\}\}$/);
+    return m ? m[1] : null;
+  }
+
+  mergeFieldLabel(key) {
+    const field = this.mergeFields().find((f) => f.key === key);
+    return field ? field.label : key;
   }
 
   // --- helpers -------------------------------------------------------------

--- a/app/javascript/controllers/chatwoot_template_form_controller.js
+++ b/app/javascript/controllers/chatwoot_template_form_controller.js
@@ -1,0 +1,211 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Drives the WhatsApp template UI inside the Chatwoot message form.
+// All template data is synced into `inboxesValue`, so the form renders fully
+// client-side: picking an official WhatsApp inbox reveals a free-text/template
+// toggle; picking a template renders its BODY variables, HEADER media input and
+// dynamic BUTTON parameters. Generated inputs are named so they nest under
+// event[additional_attributes][...] and map to the Event template helpers.
+export default class extends Controller {
+  static targets = [
+    "inboxSelect",
+    "templateMode",
+    "modeToggle",
+    "templateSection",
+    "templateSelect",
+    "bodyParams",
+    "headerMedia",
+    "buttonParams",
+    "preview",
+    "contentSection",
+  ];
+  static values = { inboxes: Array, saved: Object };
+
+  connect() {
+    // On edit, the inbox select is not pre-selected by Rails (jsonb hash), so
+    // restore it from the saved value before deriving the rest of the state.
+    if (this.savedValue.inbox_id && this.hasInboxSelectTarget) {
+      this.inboxSelectTarget.value = String(this.savedValue.inbox_id);
+    }
+    this.inboxChanged();
+  }
+
+  inboxChanged() {
+    const inbox = this.selectedInbox();
+    const isWhatsapp = inbox && inbox.channel_type === "Channel::Whatsapp";
+
+    this.modeToggleTarget.hidden = !isWhatsapp;
+    if (!isWhatsapp) {
+      this.useFreeText();
+      return;
+    }
+    this.populateTemplates(inbox);
+    this.applyMode();
+  }
+
+  // Free-text vs template radio toggle.
+  modeChanged() {
+    this.applyMode();
+  }
+
+  applyMode() {
+    if (this.isTemplateMode()) {
+      this.contentSectionTarget.hidden = true;
+      this.templateSectionTarget.hidden = false;
+      this.templateChanged();
+    } else {
+      this.useFreeText();
+    }
+  }
+
+  useFreeText() {
+    this.contentSectionTarget.hidden = false;
+    this.templateSectionTarget.hidden = true;
+    this.templateSelectTarget.value = "";
+    this.clearDynamicFields();
+  }
+
+  populateTemplates(inbox) {
+    // On edit, restore the saved template; otherwise keep the current selection.
+    const desired = this.templateSelectTarget.value || this.savedValue.template_name || "";
+    const options = ['<option value="">—</option>'];
+    (inbox.message_templates || []).forEach((t) => {
+      options.push(`<option value="${t.name}">${t.name}</option>`);
+    });
+    this.templateSelectTarget.innerHTML = options.join("");
+    this.templateSelectTarget.value = desired;
+  }
+
+  templateChanged() {
+    this.clearDynamicFields();
+    const template = this.selectedTemplate();
+    if (!template) return;
+
+    const components = template.components || [];
+    this.renderBodyParams(components);
+    this.renderHeaderMedia(components);
+    this.renderButtonParams(components);
+    this.updatePreview();
+  }
+
+  renderBodyParams(components) {
+    const body = components.find((c) => c.type === "BODY");
+    if (!body) return;
+    const examples = (body.example && body.example.body_text && body.example.body_text[0]) || [];
+    const saved = this.savedValue.body_params || {};
+    this.bodyVarIndexes(body.text).forEach((index, position) => {
+      this.bodyParamsTarget.appendChild(
+        this.field(
+          `event[additional_attributes][template_body_params][${index}]`,
+          `Variável {{${index}}}`,
+          examples[position] || "",
+          saved[index] || "",
+          "body-param",
+        ),
+      );
+    });
+  }
+
+  renderHeaderMedia(components) {
+    const header = components.find((c) => c.type === "HEADER");
+    if (!this.isMediaHeader(header)) return;
+    this.headerMediaTarget.appendChild(
+      this.field(
+        "event[additional_attributes][template_header_media_url]",
+        `URL da mídia (${header.format.toLowerCase()})`,
+        "https://...",
+        this.savedValue.header_media_url || "",
+      ),
+    );
+  }
+
+  renderButtonParams(components) {
+    const saved = this.savedValue.button_params || {};
+    this.dynamicButtons(components).forEach((button, index) => {
+      this.buttonParamsTarget.appendChild(
+        this.field(
+          `event[additional_attributes][template_button_params][${index}]`,
+          `Parâmetro do botão "${button.text}"`,
+          "",
+          saved[index] || "",
+        ),
+      );
+    });
+  }
+
+  updatePreview() {
+    if (!this.hasPreviewTarget) return;
+    const template = this.selectedTemplate();
+    const body = (template.components || []).find((c) => c.type === "BODY");
+    let text = (body && body.text) || "";
+    this.bodyParamsTarget.querySelectorAll("input").forEach((input) => {
+      const index = input.name.match(/\[template_body_params\]\[(\d+)\]/)[1];
+      text = text.replace(`{{${index}}}`, input.value || `{{${index}}}`);
+    });
+    this.previewTarget.textContent = text;
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  selectedInbox() {
+    const select = this.hasInboxSelectTarget
+      ? this.inboxSelectTarget
+      : this.element.querySelector("select[name*='chatwoot_inbox_id']");
+    const id = select ? select.value : null;
+    return this.inboxesValue.find((i) => String(i.id) === String(id));
+  }
+
+  selectedTemplate() {
+    const inbox = this.selectedInbox();
+    if (!inbox) return null;
+    return (inbox.message_templates || []).find((t) => t.name === this.templateSelectTarget.value);
+  }
+
+  isTemplateMode() {
+    const radio = this.templateModeTargets.find((r) => r.checked);
+    return radio ? radio.value === "template" : false;
+  }
+
+  bodyVarIndexes(text) {
+    const matches = (text || "").match(/\{\{(\d+)\}\}/g) || [];
+    return [...new Set(matches.map((m) => m.replace(/\D/g, "")))];
+  }
+
+  isMediaHeader(header) {
+    return header && ["IMAGE", "VIDEO", "DOCUMENT"].includes(header.format);
+  }
+
+  dynamicButtons(components) {
+    const buttons = components.find((c) => c.type === "BUTTONS");
+    return ((buttons && buttons.buttons) || []).filter(
+      (b) => b.type === "URL" && /\{\{\d+\}\}/.test(b.url || ""),
+    );
+  }
+
+  clearDynamicFields() {
+    [this.bodyParamsTarget, this.headerMediaTarget, this.buttonParamsTarget].forEach((el) => {
+      el.innerHTML = "";
+    });
+    if (this.hasPreviewTarget) this.previewTarget.textContent = "";
+  }
+
+  field(name, label, placeholder, value, action) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "space-y-1 mt-2";
+    const labelEl = document.createElement("label");
+    labelEl.className = "typography-text-s-lh150 text-dark-gray-palette-p1";
+    labelEl.textContent = label;
+    const input = document.createElement("input");
+    input.type = "text";
+    input.name = name;
+    input.placeholder = placeholder;
+    input.value = value || "";
+    input.className = "form-input w-full";
+    if (action === "body-param") {
+      input.setAttribute("data-action", "input->chatwoot-template-form#updatePreview");
+    }
+    wrapper.appendChild(labelEl);
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+}

--- a/app/models/apps/chatwoot.rb
+++ b/app/models/apps/chatwoot.rb
@@ -100,7 +100,9 @@ class Apps::Chatwoot < ApplicationRecord
       { 'api_access_token': chatwoot_user_token.to_s, 'Content-Type': 'application/json' }
     )
 
-    self.inboxes = Accounts::Apps::Chatwoots::GetInboxes.call(self)[:ok]
+    self.inboxes = Accounts::Apps::Chatwoots::SyncInboxTemplates.call(
+      self, Accounts::Apps::Chatwoots::GetInboxes.call(self)[:ok]
+    )
 
     if dashboard_apps_response.status == 200 && webhook_response.status == 200
       dashboard_apps_body = JSON.parse(dashboard_apps_response.body)

--- a/app/models/apps/chatwoot/connection/refresh.rb
+++ b/app/models/apps/chatwoot/connection/refresh.rb
@@ -11,7 +11,7 @@ class Apps::Chatwoot::Connection::Refresh
     inboxes = Accounts::Apps::Chatwoots::GetInboxes.call(@chatwoot)
 
     if inboxes.key?(:ok)
-      @chatwoot.inboxes = inboxes[:ok]
+      @chatwoot.inboxes = Accounts::Apps::Chatwoots::SyncInboxTemplates.call(@chatwoot, inboxes[:ok])
       @chatwoot.save!
     end
     true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -139,7 +139,7 @@ class Event < ApplicationRecord
     return content if template.nil?
 
     body = Array(template['components']).find { |c| c['type'] == 'BODY' }
-    params = additional_attributes['template_body_params'] || {}
+    params = resolved_template_body_params
     body.to_h['text'].to_s.gsub(/\{\{(\d+)\}\}/) { params[Regexp.last_match(1)].to_s }
   end
 
@@ -160,13 +160,13 @@ class Event < ApplicationRecord
     components = Array(template['components'])
     processed = {}
 
-    body_params = additional_attributes['template_body_params'] || {}
+    body_params = resolved_template_body_params
     processed['body'] = body_params if body_params.present?
 
     header = components.find { |c| c['type'] == 'HEADER' }
     if chatwoot_media_header?(header) && additional_attributes['template_header_media_url'].present?
       processed['header'] = {
-        'media_url' => additional_attributes['template_header_media_url'],
+        'media_url' => resolve_merge_tags(additional_attributes['template_header_media_url']),
         'media_type' => header['format'].to_s.downcase
       }
     end
@@ -187,8 +187,59 @@ class Event < ApplicationRecord
   def chatwoot_processed_buttons(template)
     button_params = additional_attributes['template_button_params'] || {}
     chatwoot_dynamic_buttons(template).each_with_index.filter_map do |_button, index|
-      value = button_params[index.to_s]
+      value = resolve_merge_tags(button_params[index.to_s])
       { 'type' => 'url', 'parameter' => value } if value.present?
+    end
+  end
+
+  CONTACT_MERGE_FIELDS = %w[full_name email phone].freeze
+
+  # Body params with {{contact.<field>}} merge tags resolved against this event's
+  # contact, so a bulk send personalises every lead. Plain values pass through.
+  def resolved_template_body_params
+    (additional_attributes['template_body_params'] || {}).transform_values { |v| resolve_merge_tags(v) }
+  end
+
+  # True when a required body variable resolves to blank for this contact (e.g. a
+  # {{contact.full_name}} mapping but the contact has no name). Bulk sends skip
+  # these leads instead of dispatching a template the WhatsApp API would reject.
+  def chatwoot_template_missing_data?
+    return false unless chatwoot_template?
+
+    template = chatwoot_template_definition
+    return false if template.nil?
+
+    body = Array(template['components']).find { |c| c['type'] == 'BODY' }
+    required = body.to_h['text'].to_s.scan(/\{\{(\d+)\}\}/).flatten
+    raw = additional_attributes['template_body_params'] || {}
+    # Only a merge tag that resolves to blank is a per-lead data gap; a blank
+    # fixed-text value is a configuration mistake caught by validation instead.
+    required.any? { |n| merge_tag?(raw[n]) && resolve_merge_tags(raw[n]).blank? }
+  end
+
+  def merge_tag?(value)
+    value.is_a?(String) && value.include?('{{contact.')
+  end
+
+  # Replaces {{contact.<field>}} tokens with the contact's value. Supports the
+  # standard fields and custom attributes via {{contact.custom.<key>}}.
+  def resolve_merge_tags(value)
+    return value unless merge_tag?(value)
+
+    value.gsub(/\{\{\s*contact\.([a-z_]+(?:\.[A-Za-z0-9_ -]+)?)\s*\}\}/) do
+      resolve_contact_field(Regexp.last_match(1))
+    end
+  end
+
+  def resolve_contact_field(key)
+    return '' if contact.blank?
+
+    if key.start_with?('custom.')
+      contact.custom_attributes.to_h[key.delete_prefix('custom.')].to_s
+    elsif CONTACT_MERGE_FIELDS.include?(key)
+      contact.public_send(key).to_s
+    else
+      ''
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -58,6 +58,10 @@ class Event < ApplicationRecord
   attribute :invalid_files
 
   validate :validate_invalid_files
+  validate :validate_chatwoot_template, if: :chatwoot_template?
+  # Persist the resolved template text as the event content so the sent message is
+  # visible in the CRM timeline (the template form hides the free-text field).
+  before_save :store_resolved_template_content, if: :chatwoot_template?
 
   def validate_invalid_files
     errors.add(:files, 'Invalid files') if invalid_files == true
@@ -109,6 +113,107 @@ class Event < ApplicationRecord
 
   def content_is_blank?(value)
     value.respond_to?(:body)
+  end
+
+  # === WhatsApp template support (Chatwoot) =================================
+  # Template inputs live in additional_attributes; the template definition
+  # (name/category/language/components) is derived at send time from the synced
+  # data on the app's inboxes, never stored on the event.
+
+  def chatwoot_template?
+    chatwoot_message? && additional_attributes['chatwoot_template_name'].present?
+  end
+
+  def chatwoot_template_definition
+    return nil unless chatwoot_template? && app.respond_to?(:inboxes)
+
+    inbox = Array(app.inboxes).find { |i| i['id'].to_s == additional_attributes['chatwoot_inbox_id'].to_s }
+    return nil unless inbox
+
+    Array(inbox['message_templates']).find { |t| t['name'] == additional_attributes['chatwoot_template_name'] }
+  end
+
+  # The BODY text with {{n}} replaced by the stored values — the required `content`.
+  def resolved_template_content
+    template = chatwoot_template_definition
+    return content if template.nil?
+
+    body = Array(template['components']).find { |c| c['type'] == 'BODY' }
+    params = additional_attributes['template_body_params'] || {}
+    body.to_h['text'].to_s.gsub(/\{\{(\d+)\}\}/) { params[Regexp.last_match(1)].to_s }
+  end
+
+  # Assembles Chatwoot's `template_params` payload from the stored inputs.
+  def chatwoot_template_params
+    template = chatwoot_template_definition
+    return nil if template.nil?
+
+    {
+      'name' => template['name'],
+      'category' => template['category'],
+      'language' => template['language'],
+      'processed_params' => chatwoot_processed_params(template)
+    }
+  end
+
+  def chatwoot_processed_params(template)
+    components = Array(template['components'])
+    processed = {}
+
+    body_params = additional_attributes['template_body_params'] || {}
+    processed['body'] = body_params if body_params.present?
+
+    header = components.find { |c| c['type'] == 'HEADER' }
+    if chatwoot_media_header?(header) && additional_attributes['template_header_media_url'].present?
+      processed['header'] = {
+        'media_url' => additional_attributes['template_header_media_url'],
+        'media_type' => header['format'].to_s.downcase
+      }
+    end
+
+    buttons = chatwoot_processed_buttons(template)
+    processed['buttons'] = buttons if buttons.present?
+
+    processed
+  end
+
+  # Only buttons that carry a runtime parameter (a URL containing {{n}}) are sent;
+  # static QUICK_REPLY / plain URL buttons come from the template itself.
+  def chatwoot_dynamic_buttons(template)
+    buttons = Array(template['components']).find { |c| c['type'] == 'BUTTONS' }.to_h['buttons']
+    Array(buttons).select { |b| b['type'] == 'URL' && b['url'].to_s =~ /\{\{\d+\}\}/ }
+  end
+
+  def chatwoot_processed_buttons(template)
+    button_params = additional_attributes['template_button_params'] || {}
+    chatwoot_dynamic_buttons(template).each_with_index.filter_map do |_button, index|
+      value = button_params[index.to_s]
+      { 'type' => 'url', 'parameter' => value } if value.present?
+    end
+  end
+
+  def chatwoot_media_header?(header)
+    header.present? && %w[IMAGE VIDEO DOCUMENT].include?(header['format'].to_s)
+  end
+
+  def store_resolved_template_content
+    self.content = resolved_template_content
+  end
+
+  def validate_chatwoot_template
+    template = chatwoot_template_definition
+    return errors.add(:base, :chatwoot_template_not_found) if template.nil?
+
+    components = Array(template['components'])
+    body = components.find { |c| c['type'] == 'BODY' }
+    body_params = additional_attributes['template_body_params'] || {}
+    required = body.to_h['text'].to_s.scan(/\{\{(\d+)\}\}/).flatten
+    errors.add(:base, :chatwoot_template_body_params_missing) if required.any? { |n| body_params[n].blank? }
+
+    header = components.find { |c| c['type'] == 'HEADER' }
+    if chatwoot_media_header?(header) && additional_attributes['template_header_media_url'].blank?
+      errors.add(:base, :chatwoot_template_header_missing)
+    end
   end
 
   def should_delivery_event_scheduled?

--- a/app/use_cases/accounts/apps/chatwoots/send_message.rb
+++ b/app/use_cases/accounts/apps/chatwoots/send_message.rb
@@ -35,7 +35,14 @@ class Accounts::Apps::Chatwoots::SendMessage
   end
 
   def self.build_body(event)
-    event.generate_content_hash('content', event.content)
+    if event.chatwoot_template?
+      # `.compact` degrades to a plain content message if the template was removed
+      # or unapproved between scheduling and delivery (template_params would be nil).
+      { 'content' => event.resolved_template_content,
+        'template_params' => event.chatwoot_template_params }.compact
+    else
+      event.generate_content_hash('content', event.content)
+    end
   end
 
   def self.request_headers(event, chatwoot)

--- a/app/use_cases/accounts/apps/chatwoots/sync_inbox_templates.rb
+++ b/app/use_cases/accounts/apps/chatwoots/sync_inbox_templates.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Enriches the inbox list with the WhatsApp message templates approved in Chatwoot.
+#
+# The /inboxes (list) endpoint does not return `message_templates`; only the
+# /inboxes/:id (detail) endpoint does. For each official WhatsApp inbox
+# (`Channel::Whatsapp`) we fetch the detail and nest a trimmed `message_templates`
+# array inside the inbox object, so the rest of the app reads a single jsonb blob
+# (`apps_chatwoots.inboxes`). Non-WhatsApp inboxes are returned untouched.
+class Accounts::Apps::Chatwoots::SyncInboxTemplates
+  WHATSAPP_CHANNEL = 'Channel::Whatsapp'
+
+  def self.call(chatwoot, inboxes)
+    return inboxes unless inboxes.is_a?(Array)
+
+    inboxes.map do |inbox|
+      next inbox unless inbox['channel_type'] == WHATSAPP_CHANNEL
+
+      detail = fetch_inbox_detail(chatwoot, inbox['id'])
+      # Keep the previous inbox object on error so a single failing inbox never
+      # wipes templates or aborts the whole refresh.
+      next inbox if detail.nil?
+
+      inbox.merge('message_templates' => trim_templates(detail['message_templates']))
+    end
+  end
+
+  def self.fetch_inbox_detail(chatwoot, inbox_id)
+    response = Faraday.get(
+      "#{chatwoot.chatwoot_endpoint_url}/api/v1/accounts/#{chatwoot.chatwoot_account_id}/inboxes/#{inbox_id}",
+      {},
+      chatwoot.request_headers
+    )
+    return nil unless response.status == 200
+
+    JSON.parse(response.body)
+  rescue Faraday::Error, JSON::ParserError => e
+    Rails.logger.error("SyncInboxTemplates failed for inbox #{inbox_id}: #{e.message}")
+    nil
+  end
+
+  # Store only what the form and the send path need, to keep the jsonb small.
+  def self.trim_templates(templates)
+    Array(templates).select { |template| template['status'] == 'APPROVED' }.map do |template|
+      template.slice('name', 'language', 'category').merge(
+        'components' => Array(template['components']).map do |component|
+          component.slice('type', 'format', 'text', 'buttons')
+        end
+      )
+    end
+  end
+end

--- a/app/views/accounts/deals/show.html.erb
+++ b/app/views/accounts/deals/show.html.erb
@@ -10,7 +10,7 @@
       <div data-controller="element-expanded">
         <%= render "/accounts/deals/details" %>
       </div>
-      <div class="">
+      <div class="min-w-0">
         <div class="gap-8">
           <div class="bg-light-palette-p5 border-2 border-neutral-150 border-light-palette-p3 rounded ">
             <%= turbo_frame_tag dom_id(Event.new), src: new_account_contact_event_path(account_id: current_user.account, contact_id: @deal.contact.id, deal_id: @deal.id), loading: :lazy do %>

--- a/app/views/accounts/pipelines/create_bulk_action.html.erb
+++ b/app/views/accounts/pipelines/create_bulk_action.html.erb
@@ -1,3 +1,3 @@
 <%= turbo_frame_tag "bulk-action-form" do %>
-  Criado <%= @result.count %> mensagens
+  <%= t('views.accounts.pipelines.bulk_action.result.created', count: @created) %>
 <% end %>

--- a/app/views/accounts/pipelines/create_bulk_action.turbo_stream.erb
+++ b/app/views/accounts/pipelines/create_bulk_action.turbo_stream.erb
@@ -1,5 +1,7 @@
 <%= turbo_stream.replace :flash_message do %>
-  <%= render partial: 'components/flash_message', locals: { message: "#{t('activerecord.models.other')}: #{@result.count}" } %>
+  <% message = t('views.accounts.pipelines.bulk_action.result.created', count: @created) %>
+  <% message = "#{message} · #{t('views.accounts.pipelines.bulk_action.result.skipped', count: @skipped.count)}" if @skipped.any? %>
+  <%= render partial: 'components/flash_message', locals: { message: message } %>
 <% end %>
 <%= turbo_stream.replace :modal do %>
   <%= turbo_frame_tag :modal %>

--- a/app/views/components/events/form/_chatwoot_message.html.erb
+++ b/app/views/components/events/form/_chatwoot_message.html.erb
@@ -1,4 +1,6 @@
-<%= form_with(model: event, url: url, namespace: 'chatwoot_connect', data: {controller: 'event-send-message-form event-form--upload-files' ,   'event-form--upload-files-pause-record-svg-url-value': asset_path('pause-record.svg'),  'event-form--upload-files-pause-wave-svg-url-value': asset_path('pause-white.svg'),  'event-form--upload-files-play-wave-svg-url-value': asset_path('play-solid-white.svg') , 'event-form--upload-files-mic-svg-url-value': asset_path('mic.svg'), 'event-form--upload-files-accepted-types-value': '["text", "video", "image", "application", "audio"]', action: action_name == 'edit' ? '' :  "drop->event-form--upload-files#acceptFiles dragenter->event-form--upload-files#showDragAlert dragleave->event-form--upload-files#removeDragAlert" }, class:"relative z-0 ") do |form|  %>
+<% chatwoot_aa = event.additional_attributes || {} %>
+<% chatwoot_is_template = chatwoot_aa['chatwoot_template_name'].present? %>
+<%= form_with(model: event, url: url, namespace: 'chatwoot_connect', data: {controller: 'event-send-message-form event-form--upload-files chatwoot-template-form' , 'chatwoot-template-form-inboxes-value': current_user.account.apps_chatwoots.last.inboxes.to_json, 'chatwoot-template-form-saved-value': { inbox_id: chatwoot_aa['chatwoot_inbox_id'], template_name: chatwoot_aa['chatwoot_template_name'], body_params: chatwoot_aa['template_body_params'], header_media_url: chatwoot_aa['template_header_media_url'], button_params: chatwoot_aa['template_button_params'] }.to_json,   'event-form--upload-files-pause-record-svg-url-value': asset_path('pause-record.svg'),  'event-form--upload-files-pause-wave-svg-url-value': asset_path('pause-white.svg'),  'event-form--upload-files-play-wave-svg-url-value': asset_path('play-solid-white.svg') , 'event-form--upload-files-mic-svg-url-value': asset_path('mic.svg'), 'event-form--upload-files-accepted-types-value': '["text", "video", "image", "application", "audio"]', action: action_name == 'edit' ? '' :  "drop->event-form--upload-files#acceptFiles dragenter->event-form--upload-files#showDragAlert dragleave->event-form--upload-files#removeDragAlert" }, class:"relative z-0 ") do |form|  %>
   <%= render '/components/events/drag_and_drop'%>
   <%= render '/components/events/form/message_errors', model: event %>
   <%= form.hidden_field :app_type, value: 'Apps::Chatwoot' %>
@@ -11,14 +13,34 @@
   <%= form.hidden_field :stage_id, value: params[:stage_id] %>
   <%= form.hidden_field :filter, value: params[:filter] %>
   <div class="p-3 mt-4 flex">
-    <div class="w-full space-y-2">
+    <div class="w-full min-w-0 overflow-x-hidden space-y-2">
       <%= form.fields_for :additional_attributes do | att | %>
         <%= att.label :chatwoot_inbox_id, t('views.components.events.form.chatwoot_message.inbox'), class:' typography-text-m-lh150 text-dark-gray-palette-p1' %>
-        <%= att.select(:chatwoot_inbox_id, current_user.account.apps_chatwoots.last.inboxes.map { | inbox | [ inbox['name'], inbox['id']]  } , {}, {class: 'form-input w-full'} ) %>
+        <%= att.select(:chatwoot_inbox_id, current_user.account.apps_chatwoots.last.inboxes.map { | inbox | [ inbox['name'], inbox['id']]  } , {}, {class: 'form-input w-full', data: { 'chatwoot-template-form-target': 'inboxSelect', action: 'change->chatwoot-template-form#inboxChanged' }} ) %>
+
+        <div data-chatwoot-template-form-target="modeToggle" hidden class="mt-3 flex gap-4">
+          <label class="flex items-center gap-1 typography-text-s-lh150">
+            <input type="radio" name="template_mode" value="free_text" <%= 'checked' unless chatwoot_is_template %> data-chatwoot-template-form-target="templateMode" data-action="change->chatwoot-template-form#modeChanged">
+            <%= t('views.components.events.form.chatwoot_message.free_text') %>
+          </label>
+          <label class="flex items-center gap-1 typography-text-s-lh150">
+            <input type="radio" name="template_mode" value="template" <%= 'checked' if chatwoot_is_template %> data-chatwoot-template-form-target="templateMode" data-action="change->chatwoot-template-form#modeChanged">
+            <%= t('views.components.events.form.chatwoot_message.template') %>
+          </label>
+        </div>
+
+        <div data-chatwoot-template-form-target="templateSection" hidden class="mt-3 space-y-2">
+          <%= att.label :chatwoot_template_name, t('views.components.events.form.chatwoot_message.template'), class:'typography-text-m-lh150 text-dark-gray-palette-p1' %>
+          <%= att.select(:chatwoot_template_name, [], { include_blank: '—' }, {class: 'form-input w-full', data: { 'chatwoot-template-form-target': 'templateSelect', action: 'change->chatwoot-template-form#templateChanged' }} ) %>
+          <div data-chatwoot-template-form-target="bodyParams"></div>
+          <div data-chatwoot-template-form-target="headerMedia"></div>
+          <div data-chatwoot-template-form-target="buttonParams"></div>
+          <p data-chatwoot-template-form-target="preview" class="typography-text-s-lh150 text-gray-pallete-p3 whitespace-pre-line break-words"></p>
+        </div>
       <% end %>
     </div>
   </div>
-  <div class="border-t border-light-palette-p3 p-3 mt-4 space-y-2">
+  <div data-chatwoot-template-form-target="contentSection" class="border-t border-light-palette-p3 p-3 mt-4 space-y-2">
     <%= form.label :content, t('views.components.events.form.chatwoot_message.content'), class:'typography-text-m-lh150 text-dark-gray-palette-p1' %>
     <%= form.text_area :content, class: 'form-input w-full h-44' %>
   </div>

--- a/config/locales/models/event/en.yml
+++ b/config/locales/models/event/en.yml
@@ -19,3 +19,11 @@ en:
         title: Type
         auto_done: 'Send message automatically'
         done: 'Mark activity as done'
+    errors:
+      models:
+        event:
+          attributes:
+            base:
+              chatwoot_template_not_found: 'Selected WhatsApp template was not found'
+              chatwoot_template_body_params_missing: 'Fill in all template variables'
+              chatwoot_template_header_missing: 'Provide the template header media URL'

--- a/config/locales/models/event/es.yml
+++ b/config/locales/models/event/es.yml
@@ -19,3 +19,11 @@ es:
         title: Tipo
         auto_done: 'Enviar mensaje automáticamente'
         done: 'Marcar actividad como hecha'
+    errors:
+      models:
+        event:
+          attributes:
+            base:
+              chatwoot_template_not_found: 'La plantilla de WhatsApp seleccionada no fue encontrada'
+              chatwoot_template_body_params_missing: 'Complete todas las variables de la plantilla'
+              chatwoot_template_header_missing: 'Proporcione la URL del medio del encabezado de la plantilla'

--- a/config/locales/models/event/pt-BR.yml
+++ b/config/locales/models/event/pt-BR.yml
@@ -19,3 +19,11 @@ pt-BR:
         title: Tipo
         auto_done: 'Enviar mensagem automaticamente'
         done: 'Marcar atividade como feita'
+    errors:
+      models:
+        event:
+          attributes:
+            base:
+              chatwoot_template_not_found: 'O template de WhatsApp selecionado não foi encontrado'
+              chatwoot_template_body_params_missing: 'Preencha todas as variáveis do template'
+              chatwoot_template_header_missing: 'Informe a URL da mídia do cabeçalho do template'

--- a/config/locales/views/accounts/pipelines/bulk_action/en.yml
+++ b/config/locales/views/accounts/pipelines/bulk_action/en.yml
@@ -5,3 +5,6 @@ en:
         bulk_action:
           form_modal:
             warning: "To prevent potential bans of the number that will send the message, a small delay will be introduced in sending the messages. However, it is important to note that the number is still subject to ban."
+          result:
+            created: "%{count} messages created"
+            skipped: "%{count} skipped (missing data)"

--- a/config/locales/views/accounts/pipelines/bulk_action/es.yml
+++ b/config/locales/views/accounts/pipelines/bulk_action/es.yml
@@ -5,3 +5,6 @@ es:
         bulk_action:
           form_modal:
             warning: "Para prevenir posibles bloqueos del número que enviará el mensaje, se introducirá un pequeño retraso en el envío de los mensajes. Sin embargo, es importante señalar que el número sigue sujeto a bloqueo."
+          result:
+            created: "%{count} mensajes creados"
+            skipped: "%{count} omitidos (sin dato)"

--- a/config/locales/views/accounts/pipelines/bulk_action/pt-BR.yml
+++ b/config/locales/views/accounts/pipelines/bulk_action/pt-BR.yml
@@ -5,3 +5,6 @@ pt-BR:
         bulk_action:
           form_modal:
             warning: "Para prevenir possíveis banimentos do número que enviará a mensagem, será introduzido um pequeno atraso no envio das mensagens. No entanto, é importante observar que o número ainda está sujeito a banimento."
+          result:
+            created: "%{count} mensagens criadas"
+            skipped: "%{count} sem dado (pulados)"

--- a/config/locales/views/components/events/form/chatwoot_message/en.yml
+++ b/config/locales/views/components/events/form/chatwoot_message/en.yml
@@ -7,3 +7,5 @@ en:
             inbox: "Inbox"
             content: "Message Content"
             confirm: Confirm
+            free_text: "Free text"
+            template: "Template"

--- a/config/locales/views/components/events/form/chatwoot_message/es.yml
+++ b/config/locales/views/components/events/form/chatwoot_message/es.yml
@@ -7,3 +7,5 @@ es:
             inbox: "Bandeja de entrada"
             content: "Contenido del mensaje"
             confirm: Confirmar
+            free_text: "Texto libre"
+            template: "Plantilla"

--- a/config/locales/views/components/events/form/chatwoot_message/pt-BR.yml
+++ b/config/locales/views/components/events/form/chatwoot_message/pt-BR.yml
@@ -7,3 +7,5 @@ pt-BR:
             inbox: "Caixa de entrada"
             content: "Conteúdo da mensagem"
             confirm: Confirmar
+            free_text: "Texto livre"
+            template: "Template"

--- a/spec/controllers/accounts/contacts/events_controller_spec.rb
+++ b/spec/controllers/accounts/contacts/events_controller_spec.rb
@@ -161,6 +161,28 @@ RSpec.describe Accounts::Contacts::EventsController, type: :request do
           expect(flash[:error]).to be_nil
         end
 
+        context 'when chatwoot message uses a whatsapp template' do
+          let!(:chatwoot_templates) do
+            create(:apps_chatwoots, :skip_validate,
+                   inboxes: [JSON.parse(File.read('spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json'))])
+          end
+
+          it 'persists the nested template params through strong params' do
+            params = valid_params.deep_merge(event: { kind: 'chatwoot_message', done: '0', app_type: 'Apps::Chatwoot',
+                                                      app_id: chatwoot_templates.id,
+                                                      scheduled_at: (Time.current + 2.hours).round, send_now: 'false',
+                                                      additional_attributes: { chatwoot_inbox_id: '101',
+                                                                               chatwoot_template_name: 'lembrete_aula',
+                                                                               template_body_params: { '1' => 'Paula', '2' => '14:00' } } })
+            expect do
+              post "/accounts/#{account.id}/contacts/#{contact.id}/events", params: params
+            end.to change(Event, :count).by(1)
+            expect(event_created.additional_attributes['template_body_params']).to eq('1' => 'Paula', '2' => '14:00')
+            expect(event_created.additional_attributes['chatwoot_template_name']).to eq('lembrete_aula')
+            expect(event_created.additional_attributes['chatwoot_inbox_id']).to eq('101')
+          end
+        end
+
         context 'when chatwoot message is scheduled and delivered' do
           it do
             params = valid_params.deep_merge(event: { kind: 'chatwoot_message', done: '0', app_type: 'Apps::Chatwoot', app_id: chatwoot.id, chatwoot_inbox_id: 1, scheduled_at: (Time.current + 2.hours).round, auto_done: true, send_now: 'false' })

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -55,6 +55,15 @@ FactoryBot.define do
         attachment.file_type = attachment.check_file_type
       end
     end
+    trait :chatwoot_template do
+      kind { 'chatwoot_message' }
+      from_me { true }
+      additional_attributes do
+        { 'chatwoot_inbox_id' => 101,
+          'chatwoot_template_name' => 'lembrete_aula',
+          'template_body_params' => { '1' => 'Paula', '2' => '14:00' } }
+      end
+    end
     trait :with_zip_file do
       after(:build) do |event|
         attachment = event.build_attachment

--- a/spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json
+++ b/spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json
@@ -1,0 +1,100 @@
+{
+  "id": 101,
+  "name": "Official WhatsApp",
+  "channel_type": "Channel::Whatsapp",
+  "message_templates": [
+    {
+      "id": "100000000000001",
+      "name": "lembrete_aula",
+      "status": "APPROVED",
+      "category": "UTILITY",
+      "language": "pt_BR",
+      "components": [
+        {
+          "text": "Oi {{1}}! Sua aula experimental e hoje as {{2}}!",
+          "type": "BODY",
+          "example": { "body_text": [["Paula", "14:00"]] }
+        },
+        {
+          "type": "BUTTONS",
+          "buttons": [
+            { "text": "Vou Participar", "type": "QUICK_REPLY" },
+            { "text": "Preciso Reagendar", "type": "QUICK_REPLY" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "100000000000002",
+      "name": "appointment_confirmation",
+      "status": "APPROVED",
+      "category": "UTILITY",
+      "language": "pt_BR",
+      "components": [
+        { "text": "Confirmacao de agendamento", "type": "HEADER", "format": "TEXT" },
+        {
+          "text": "Ola {{1}},\nSua aula esta agendada para {{2}} as {{3}}.",
+          "type": "BODY",
+          "example": { "body_text": [["John", "05/06/26", "10:00h"]] }
+        },
+        {
+          "type": "BUTTONS",
+          "buttons": [
+            { "text": "Confirmar", "type": "QUICK_REPLY" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "100000000000003",
+      "name": "flight_confirmation",
+      "status": "APPROVED",
+      "category": "UTILITY",
+      "language": "pt_BR",
+      "components": [
+        { "type": "HEADER", "format": "DOCUMENT" },
+        {
+          "text": "Esta e a confirmacao do seu voo para {{1}}.",
+          "type": "BODY",
+          "example": { "body_text": [["Recife"]] }
+        },
+        { "text": "Mensagem automatica.", "type": "FOOTER" }
+      ]
+    },
+    {
+      "id": "100000000000004",
+      "name": "validation_code",
+      "status": "APPROVED",
+      "category": "AUTHENTICATION",
+      "language": "pt_BR",
+      "components": [
+        {
+          "text": "Seu codigo de verificacao e *{{1}}*.",
+          "type": "BODY",
+          "example": { "body_text": [["123456"]] }
+        },
+        {
+          "type": "BUTTONS",
+          "buttons": [
+            {
+              "url": "https://www.whatsapp.com/otp/code/?otp_type=COPY_CODE&code=otp{{1}}",
+              "text": "Copiar codigo",
+              "type": "URL",
+              "example": ["https://www.whatsapp.com/otp/code/?otp_type=COPY_CODE&code=otp123456"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "100000000000005",
+      "name": "not_approved_template",
+      "status": "PENDING",
+      "category": "MARKETING",
+      "language": "pt_BR",
+      "components": [
+        { "text": "Promo {{1}}", "type": "BODY" }
+      ]
+    }
+  ]
+}

--- a/spec/integration/use_cases/accounts/apps/chatwoots/messages/delivery_job_spec.rb
+++ b/spec/integration/use_cases/accounts/apps/chatwoots/messages/delivery_job_spec.rb
@@ -25,5 +25,41 @@ RSpec.describe Accounts::Apps::Chatwoots::Messages::DeliveryJob, type: :request 
 
       expect(result[:ok].additional_attributes['chatwoot_id']).to eq(227)
     end
+
+    context 'when the event is a whatsapp template' do
+      let(:inbox) { JSON.parse(File.read('spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json')) }
+      let(:chatwoot) { create(:apps_chatwoots, :skip_validate, inboxes: [inbox]) }
+      let(:event) do
+        create(:event, app: chatwoot, account:, contact:, from_me: true, scheduled_at: Time.now,
+                       kind: 'chatwoot_message',
+                       additional_attributes: { 'chatwoot_inbox_id' => 101,
+                                                'chatwoot_template_name' => 'lembrete_aula',
+                                                'template_body_params' => { '1' => 'Paula', '2' => '14:00' } })
+      end
+
+      let(:create_conversation_response) do
+        File.read('spec/integration/use_cases/accounts/apps/chatwoots/create_conversation.json')
+      end
+
+      it 'posts the resolved content and template params to chatwoot' do
+        stub_request(:get, /conversations/)
+          .to_return(body: { payload: [] }.to_json, status: 200, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, /conversations/)
+          .to_return(body: create_conversation_response, status: 200, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:post, /messages/)
+          .to_return(body: message_response, status: 200, headers: { 'Content-Type' => 'application/json' })
+
+        described_class.perform_now(event.id)
+
+        expect(a_request(:post, /messages/).with do |req|
+          body = JSON.parse(req.body)
+          body['content'] == 'Oi Paula! Sua aula experimental e hoje as 14:00!' &&
+            body['template_params'] == {
+              'name' => 'lembrete_aula', 'category' => 'UTILITY', 'language' => 'pt_BR',
+              'processed_params' => { 'body' => { '1' => 'Paula', '2' => '14:00' } }
+            }
+        end).to have_been_made
+      end
+    end
   end
 end

--- a/spec/integration/use_cases/accounts/apps/chatwoots/send_message_spec.rb
+++ b/spec/integration/use_cases/accounts/apps/chatwoots/send_message_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe Accounts::Apps::Chatwoots::SendMessage, type: :request do
       end
     end
   end
+
+  describe '.build_body' do
+    let(:account) { create(:account) }
+    let(:inbox) { JSON.parse(File.read('spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json')) }
+    let(:chatwoot) { create(:apps_chatwoots, :skip_validate, account:, inboxes: [inbox]) }
+    let(:contact) { create(:contact, account:) }
+
+    it 'returns a plain content hash for a free-text message' do
+      event = build(:event, kind: 'chatwoot_message', app: chatwoot, contact:, deal: nil, content: 'Hi Lorena')
+      expect(described_class.build_body(event)).to eq('content' => 'Hi Lorena')
+    end
+
+    it 'includes template_params and resolved content for a template message' do
+      event = build(:event, kind: 'chatwoot_message', app: chatwoot, contact:, deal: nil,
+                            additional_attributes: { 'chatwoot_inbox_id' => 101,
+                                                     'chatwoot_template_name' => 'lembrete_aula',
+                                                     'template_body_params' => { '1' => 'Paula', '2' => '14:00' } })
+      body = described_class.build_body(event)
+      expect(body['content']).to eq('Oi Paula! Sua aula experimental e hoje as 14:00!')
+      expect(body['template_params']['name']).to eq('lembrete_aula')
+      expect(body['template_params']['processed_params']).to eq('body' => { '1' => 'Paula', '2' => '14:00' })
+    end
+  end
 end

--- a/spec/integration/use_cases/accounts/apps/chatwoots/sync_inbox_templates_spec.rb
+++ b/spec/integration/use_cases/accounts/apps/chatwoots/sync_inbox_templates_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Accounts::Apps::Chatwoots::SyncInboxTemplates, type: :request do
+  let(:chatwoot) { create(:apps_chatwoots, :skip_validate) }
+  let(:inbox_detail) { File.read('spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json') }
+  let(:inboxes) do
+    [{ 'id' => 101, 'name' => 'Official WhatsApp', 'channel_type' => 'Channel::Whatsapp' },
+     { 'id' => 200, 'name' => 'Evolution', 'channel_type' => 'Channel::Api' }]
+  end
+
+  def detail_url(inbox_id)
+    "#{chatwoot.chatwoot_endpoint_url}/api/v1/accounts/#{chatwoot.chatwoot_account_id}/inboxes/#{inbox_id}"
+  end
+
+  it 'enriches whatsapp inboxes with approved templates and leaves other channels untouched' do
+    stub_request(:get, detail_url(101))
+      .to_return(body: inbox_detail, status: 200, headers: { 'Content-Type' => 'application/json' })
+
+    result = described_class.call(chatwoot, inboxes)
+    whatsapp = result.find { |inbox| inbox['id'] == 101 }
+    evolution = result.find { |inbox| inbox['id'] == 200 }
+
+    expect(whatsapp['message_templates'].map { |template| template['name'] })
+      .to match_array(%w[lembrete_aula appointment_confirmation flight_confirmation validation_code])
+    expect(whatsapp['message_templates']).to all(include('name', 'language', 'category', 'components'))
+    expect(evolution).not_to have_key('message_templates')
+  end
+
+  it 'keeps the inbox untouched when the detail request fails' do
+    stub_request(:get, detail_url(101)).to_return(status: 500, body: 'error')
+
+    result = described_class.call(chatwoot, inboxes)
+    expect(result.find { |inbox| inbox['id'] == 101 }).not_to have_key('message_templates')
+  end
+
+  it 'returns the input unchanged when it is not an array' do
+    expect(described_class.call(chatwoot, nil)).to be_nil
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -221,6 +221,42 @@ RSpec.describe Event do
           .to include(I18n.t('activerecord.errors.models.event.attributes.base.chatwoot_template_not_found'))
       end
     end
+
+    context 'merge tags (per-lead variables)' do
+      let(:contact) { create(:contact, account:, full_name: 'Lorena') }
+
+      it 'resolves a {{contact.field}} body variable to this lead value' do
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                               'template_body_params' => { '1' => '{{contact.full_name}}', '2' => '14:00' })
+
+        expect(event.resolved_template_content).to eq('Oi Lorena! Sua aula experimental e hoje as 14:00!')
+        expect(event.chatwoot_template_params['processed_params']['body']).to eq('1' => 'Lorena', '2' => '14:00')
+        expect(event.chatwoot_template_missing_data?).to be false
+      end
+
+      it 'resolves a custom-attribute merge tag' do
+        contact.update!(custom_attributes: { 'codigo' => 'ABC123' })
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                               'template_body_params' => { '1' => '{{contact.full_name}}', '2' => '{{contact.custom.codigo}}' })
+
+        expect(event.chatwoot_template_params['processed_params']['body']).to eq('1' => 'Lorena', '2' => 'ABC123')
+      end
+
+      it 'reports missing data when a mapped field has no value for the lead' do
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                               'template_body_params' => { '1' => '{{contact.custom.codigo}}', '2' => '14:00' })
+
+        expect(event.chatwoot_template_missing_data?).to be true
+      end
+
+      it 'treats a blank fixed-text value as a config error, not a per-lead skip' do
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                               'template_body_params' => { '1' => '', '2' => '14:00' })
+
+        expect(event.chatwoot_template_missing_data?).to be false
+        expect(event).to be_invalid
+      end
+    end
   end
 
   context 'editable?' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -121,6 +121,108 @@ RSpec.describe Event do
       end
     end
   end
+  context 'chatwoot whatsapp template' do
+    let(:account) { create(:account) }
+    let(:inbox) { JSON.parse(File.read('spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json')) }
+    let(:chatwoot) { create(:apps_chatwoots, :skip_validate, account:, inboxes: [inbox]) }
+    let(:contact) { create(:contact, account:) }
+
+    def template_event(attributes)
+      build(:event, kind: 'chatwoot_message', from_me: true, app: chatwoot, contact:, deal: nil,
+                    additional_attributes: attributes)
+    end
+
+    it 'resolves the definition, content and params of a body-only template' do
+      event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                             'template_body_params' => { '1' => 'Paula', '2' => '14:00' })
+
+      expect(event.chatwoot_template?).to be true
+      expect(event.chatwoot_template_definition['name']).to eq('lembrete_aula')
+      expect(event.resolved_template_content).to eq('Oi Paula! Sua aula experimental e hoje as 14:00!')
+      expect(event.chatwoot_template_params).to eq(
+        'name' => 'lembrete_aula', 'category' => 'UTILITY', 'language' => 'pt_BR',
+        'processed_params' => { 'body' => { '1' => 'Paula', '2' => '14:00' } }
+      )
+    end
+
+    it 'ignores a static TEXT header (no header in processed params)' do
+      event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'appointment_confirmation',
+                             'template_body_params' => { '1' => 'John', '2' => '05/06/26', '3' => '10:00h' })
+
+      expect(event.chatwoot_template_params['processed_params']).to eq('body' => { '1' => 'John', '2' => '05/06/26',
+                                                                                   '3' => '10:00h' })
+    end
+
+    it 'includes media header for a media-header template' do
+      event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'flight_confirmation',
+                             'template_body_params' => { '1' => 'Recife' },
+                             'template_header_media_url' => 'https://files.example/ticket.pdf')
+
+      expect(event.chatwoot_template_params['processed_params']).to eq(
+        'body' => { '1' => 'Recife' },
+        'header' => { 'media_url' => 'https://files.example/ticket.pdf', 'media_type' => 'document' }
+      )
+    end
+
+    it 'sends only dynamic URL buttons in processed params' do
+      event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'validation_code',
+                             'template_body_params' => { '1' => '123456' },
+                             'template_button_params' => { '0' => '123456' })
+
+      expect(event.chatwoot_template_params['processed_params']).to eq(
+        'body' => { '1' => '123456' },
+        'buttons' => [{ 'type' => 'url', 'parameter' => '123456' }]
+      )
+    end
+
+    it 'stores the resolved template text as content on save so it shows in the CRM timeline' do
+      event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                             'template_body_params' => { '1' => 'Paula', '2' => '14:00' })
+      event.save!
+      expect(event.reload.content.to_s).to eq('Oi Paula! Sua aula experimental e hoje as 14:00!')
+    end
+
+    it 'falls back to plain content when the chosen template no longer exists' do
+      event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'ghost')
+      event.content = 'plain fallback'
+
+      expect(event.chatwoot_template_definition).to be_nil
+      expect(event.chatwoot_template_params).to be_nil
+      expect(event.resolved_template_content).to eq('plain fallback')
+    end
+
+    context 'validation' do
+      it 'is valid as free text on a whatsapp inbox (no template selected)' do
+        event = build(:event, kind: 'chatwoot_message', from_me: true, app: chatwoot, contact:, deal: nil,
+                              content: 'oi', additional_attributes: { 'chatwoot_inbox_id' => 101 })
+        expect(event).to be_valid
+      end
+
+      it 'is invalid when a required body variable is missing' do
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'lembrete_aula',
+                               'template_body_params' => { '1' => 'Paula' })
+        expect(event).to be_invalid
+        expect(event.errors[:base])
+          .to include(I18n.t('activerecord.errors.models.event.attributes.base.chatwoot_template_body_params_missing'))
+      end
+
+      it 'is invalid when a media header url is missing' do
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'flight_confirmation',
+                               'template_body_params' => { '1' => 'Recife' })
+        expect(event).to be_invalid
+        expect(event.errors[:base])
+          .to include(I18n.t('activerecord.errors.models.event.attributes.base.chatwoot_template_header_missing'))
+      end
+
+      it 'is invalid when the chosen template is not found' do
+        event = template_event('chatwoot_inbox_id' => 101, 'chatwoot_template_name' => 'ghost')
+        expect(event).to be_invalid
+        expect(event.errors[:base])
+          .to include(I18n.t('activerecord.errors.models.event.attributes.base.chatwoot_template_not_found'))
+      end
+    end
+  end
+
   context 'editable?' do
     let(:account) { create(:account) }
     let!(:event_done) { create(:event, done: true, scheduled_at: Time.current, kind: 'note', account:) }

--- a/spec/requests/accounts/pipelines/bulk_template_merge_tags_spec.rb
+++ b/spec/requests/accounts/pipelines/bulk_template_merge_tags_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+# Bulk send of a WhatsApp template whose variable is mapped to a contact field
+# ({{contact.custom.codigo}}). Leads that have the value get an event; leads
+# missing it are skipped (not dispatched, since WhatsApp would reject a blank
+# variable) and reported.
+RSpec.describe 'Bulk template send with merge tags', type: :request do
+  let!(:account) { create(:account) }
+  let!(:user) { create(:user, account:) }
+  let(:inbox) { JSON.parse(File.read('spec/integration/use_cases/accounts/apps/chatwoots/inbox_detail.json')) }
+  let!(:chatwoot) { create(:apps_chatwoots, :skip_validate, account:, inboxes: [inbox]) }
+  let!(:pipeline) { create(:pipeline) }
+  let!(:stage) { create(:stage, pipeline:) }
+  let!(:lead_with_data) do
+    create(:deal, stage:, pipeline:,
+                  contact: create(:contact, account:, full_name: 'Lorena', custom_attributes: { 'codigo' => 'A1' }))
+  end
+  let!(:lead_without_data) do
+    create(:deal, stage:, pipeline:, contact: create(:contact, account:, full_name: 'João'))
+  end
+
+  before { sign_in(user) }
+
+  it 'creates an event only for the lead that has the mapped value, and skips the other' do
+    expect do
+      post create_bulk_action_account_pipeline_path(account, pipeline),
+           headers: { 'Accept' => 'text/vnd.turbo-stream.html' },
+           params: {
+             event: {
+               kind: 'chatwoot_message', app_type: 'Apps::Chatwoot', app_id: chatwoot.id, from_me: true,
+               send_now: 'true', stage_id: stage.id, filter: '{}',
+               additional_attributes: {
+                 chatwoot_inbox_id: 101, chatwoot_template_name: 'lembrete_aula',
+                 template_body_params: { '1' => '{{contact.custom.codigo}}', '2' => '14:00' }
+               }
+             }
+           }
+    end.to change(Event, :count).by(1)
+
+    expect(response).to have_http_status(:ok)
+    expect(Event.last.contact).to eq(lead_with_data.contact)
+  end
+end


### PR DESCRIPTION
## Problem

WhatsApp official inboxes (`Channel::Whatsapp`) require an **approved template** to message a contact outside the 24-hour customer service window. Today woofed can only send plain text through Chatwoot (`SendMessage#build_body` posts `{ content }`), so scheduled "Chatwoot message" events to those inboxes silently fail to deliver once the window is closed.

This was hit in a real self-hosted instance using official WhatsApp inboxes.

## What this adds

End-to-end WhatsApp template support for the scheduled Chatwoot message flow:

- **Template sync** — `Accounts::Apps::Chatwoots::SyncInboxTemplates` fetches the approved `message_templates` of each `Channel::Whatsapp` inbox via `GET /inboxes/:id` (the list endpoint omits them) and stores a trimmed copy nested inside the existing `apps_chatwoots.inboxes` jsonb. Wired into both inbox write sites (`chatwoot_create_flow` and the daily `Connection::Refresh`) so it stays a single source of truth. **No migration.**
- **Event helpers** — `chatwoot_template?`, `chatwoot_template_definition`, `resolved_template_content`, `chatwoot_template_params`. Name/category/language and the `processed_params` (BODY variables, HEADER media, dynamic URL BUTTON parameters) are derived at send time from the synced definition. Template inputs are stored as index-keyed hashes in `additional_attributes` to remain permit-safe under `permit(additional_attributes: {})`.
- **Sending** — `SendMessage#build_body` includes `template_params` and the resolved `content` when the event is a template; free-text behaviour is unchanged.
- **Timeline visibility** — a `before_save` stores the resolved template text as the event `content`, so the sent message shows in the CRM timeline (the template form hides the free-text field).
- **Hotwire UI** — a Stimulus controller reveals a free-text/template toggle for official WhatsApp inboxes, renders the template's variables client-side from the synced data, restores the saved state on edit, and previews the resolved text.
- **Layout** — `min-w-0` / `overflow-x-hidden` so the wider template form does not force horizontal page scroll inside the deal grid column.
- **Validation + i18n** (en/es/pt-BR) for missing template variables / header media.

## Payload

```jsonc
POST /conversations/:id/messages
{
  "content": "resolved body text",
  "template_params": {
    "name": "appointment_confirmation",
    "category": "UTILITY",
    "language": "pt_BR",
    "processed_params": {
      "body": { "1": "John", "2": "10:00" },
      "header": { "media_url": "...", "media_type": "document" },
      "buttons": [{ "type": "url", "parameter": "..." }]
    }
  }
}
```

## Tests

Specs cover the Event helpers, `build_body` (template vs free-text), an end-to-end `DeliveryJob` asserting the request `template_params`, `SyncInboxTemplates` (APPROVED-only, non-WhatsApp untouched, error resilience), and strong-params persistence of the nested template inputs. A real `GET /inboxes/:id` shaped fixture pins the components/buttons parser.

Verified end-to-end against a live instance: a template was delivered by WhatsApp to a contact whose 24h window had been closed for ~27 days (a plain-text message would have been rejected), confirming it is sent as an HSM template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)