### PR TITLE
Fix deal event lists stuck on skeleton loaders

### DIFF
--- a/app/controllers/accounts/deals_controller.rb
+++ b/app/controllers/accounts/deals_controller.rb
@@ -129,17 +129,21 @@ class Accounts::DealsController < InternalController
 
   def events_to_do
     @pagy, @events = pagy(@deal.contact.events.where(deal_id: [nil, @deal.id]).to_do, items: 5)
+    # HTML is the default so the lazy turbo-frame's initial load replaces its
+    # skeleton placeholder. Pagination requests ask for turbo_stream explicitly
+    # via the `.turbo_stream` URL format, which appends the next page. Browsers
+    # send `Accept: */*` for these frames, so turbo_stream must not come first.
     respond_to do |format|
-      format.turbo_stream
       format.html
+      format.turbo_stream
     end
   end
 
   def events_done
     @pagy, @events = pagy(@deal.contact.events.where(deal_id: [nil, @deal.id]).done, items: 5)
     respond_to do |format|
-      format.turbo_stream
       format.html
+      format.turbo_stream
     end
   end
 

--- a/spec/requests/accounts/deals/event_frames_spec.rb
+++ b/spec/requests/accounts/deals/event_frames_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+# Regression: the deal page loads its scheduled ("to do") and completed ("done")
+# event lists through lazy turbo-frames. The frame's initial request must be
+# answered with the matching <turbo-frame> HTML so it REPLACES the skeleton
+# placeholder. If it is answered with a turbo_stream (append), the skeletons are
+# never removed and real events stack underneath them. Browsers send
+# `Accept: */*` for these frames, so HTML must win content negotiation; the
+# turbo_stream (append) response is reserved for explicit `.turbo_stream`
+# pagination requests.
+RSpec.describe 'Deal event frames', type: :request do
+  let!(:account) { create(:account) }
+  let!(:user) { create(:user, account:) }
+  let!(:pipeline) { create(:pipeline) }
+  let!(:stage) { create(:stage, pipeline:) }
+  let!(:contact) { create(:contact) }
+  let!(:deal) { create(:deal, contact:, stage:, pipeline:) }
+  let(:frame_id) { "events_to_do_#{contact.id}" }
+
+  before { sign_in(user) }
+
+  it 'replaces the skeleton: answers the lazy frame with a turbo-frame, not a turbo_stream' do
+    get events_to_do_account_deal_path(account, deal),
+        headers: { 'Accept' => '*/*', 'Turbo-Frame' => frame_id }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(%(turbo-frame id="#{frame_id}"))
+    expect(response.body).not_to include(%(turbo-stream action="append" target="#{frame_id}"))
+  end
+
+  it 'appends the next page only when turbo_stream is requested explicitly' do
+    get events_to_do_account_deal_path(account, deal, format: :turbo_stream)
+
+    expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+    expect(response.body).to include(%(turbo-stream action="append" target="#{frame_id}"))
+  end
+end


### PR DESCRIPTION
## Problem

On the deal page, the **scheduled ("to do")** and **completed ("done")** event lists load through lazy `<turbo-frame>` elements whose placeholder content is a skeleton loader. In practice the skeletons never go away:

- an empty "to do" list stays showing skeleton cards;
- "done" shows skeleton cards *above* the real events.

## Cause

The frame's initial `GET` must be answered with the matching `<turbo-frame id="…">` HTML so Turbo **replaces** the skeleton. But `Accounts::DealsController#events_to_do` / `#events_done` declared `respond_to` with `turbo_stream` **before** `html`. Browsers send `Accept: */*` for these lazy frame requests, so Rails picked the first declared format — `turbo_stream` — and answered with a `turbo_stream.append`. Appending adds events *after* the skeleton placeholders and never removes them.

```
Processing by Accounts::DealsController#events_to_do as */*
```

## Fix

Reorder `respond_to` so `html` is the default (frame replacement). The pagination sub-frames request `turbo_stream` explicitly via the `.turbo_stream` URL format, so they are unaffected by the ordering and keep appending the next page.

## Tests

`spec/requests/accounts/deals/event_frames_spec.rb` covers both paths: the default lazy request returns the `<turbo-frame>` (not an append stream), and an explicit `.turbo_stream` request still appends the next page.